### PR TITLE
Optimize the listener close process

### DIFF
--- a/memconn_pipe_go110.go
+++ b/memconn_pipe_go110.go
@@ -14,3 +14,12 @@ import (
 func Pipe() (net.Conn, net.Conn) {
 	return net.Pipe()
 }
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}

--- a/memconn_pipe_wrapper.go
+++ b/memconn_pipe_wrapper.go
@@ -9,15 +9,6 @@ type pipeWrapper struct {
 	net.Conn
 	localAddr  Addr
 	remoteAddr Addr
-	onClose    func()
-}
-
-func (p *pipeWrapper) Close() error {
-	err := p.Conn.Close()
-	if p.onClose != nil {
-		p.onClose()
-	}
-	return err
 }
 
 func (p pipeWrapper) LocalAddr() net.Addr {


### PR DESCRIPTION
This patch refactors how listeners are closed with relationship to pending I/O. While the provider must track connections in order to prevent a duplicate address from listening on a specified network, the remote endpoints that spawn from these connections need not have unique addresses. To this end a listener no longer cares about tracking active connections and the connection doesn't need to remove itself from the tracker. Instead an event system with a done channel is used so that when a listener is closed all of its pending I/O is unblocked and closed immediately.

cc @dougm 