### PR TITLE
Make generated laddr more likely to be unique by adding some random data

### DIFF
--- a/memconn_provider.go
+++ b/memconn_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -204,7 +205,7 @@ func (p *Provider) DialMemContext(
 		// epoch in nanoseconds. This value need not be unique.
 		if laddr == nil {
 			laddr = &Addr{
-				Name:    fmt.Sprintf("%d", time.Now().UnixNano()),
+				Name:    fmt.Sprintf("%d-%d", time.Now().UnixNano(), rand.Uint32()),
 				network: network,
 			}
 		} else {


### PR DESCRIPTION
On windows where clock resolution is lower, multiple connections can often be established at the same moment, and get the same laddr name (because multiple calls to UnixNano() return the same value).

I see the comment that says that the laddr value need not be unique, however, it's more convenient if it is, since that's what would typically happen with the standard net dialer.